### PR TITLE
removed extra padding on top

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -3,7 +3,7 @@ import ResponsiveToggle from "./ResponsiveToggle.astro";
 import { DarkMode } from "accessible-astro-components";
 ---
 
-<div id="main-navigation" class="is-desktop py-4">
+<div id="main-navigation" class="is-desktop py-2">
   <div class="container">
     <a href="/" class="flex items-center gap-2 !no-underline">
       <img


### PR DESCRIPTION
## Description

Extra padding on top of page removed.

## Related Issue

#79

## Acceptance Criteria

 - [x] Padding no longer exists before the nav bar.

## Type of Changes

Use a check for  ✓ the following type of changes: 

|     | Type                       |
| --- | -------------------------- |
|   ✓  | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/101027036/236357443-a878f356-72b7-4d93-83b1-1de5eb16dd3b.png)

### After

![image](https://user-images.githubusercontent.com/101027036/236357420-a68b87f5-f8ff-4795-b356-770513862aca.png)

## Testing Steps / QA Criteria

Visually confirmed.
